### PR TITLE
Fix #23

### DIFF
--- a/.github/workflows/merge-main-to-publish.yml
+++ b/.github/workflows/merge-main-to-publish.yml
@@ -1,0 +1,14 @@
+name: Merge main to publish branch
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  merge-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: emiliopedrollo/auto-merge@v1.2.0
+        with:
+          github_token: ${{ github.token }}
+          target_branch: 'publish'


### PR DESCRIPTION
- `main` 브랜치가 푸시되면 자동으로 `publish`로 머지합니다.
- Thanks to  Emilio B. Pedrollo (https://github.com/marketplace/actions/auto-branch-merger)