### PR TITLE
Refactor #47

### DIFF
--- a/posts/Markdown Test.md
+++ b/posts/Markdown Test.md
@@ -49,6 +49,7 @@ Unordered
 
 - Create a list by starting a line with `+`, `-`, or `*`
 - Sub-lists are made by indenting 2 spaces:
+
   - Marker character change forces new list start:
 
     - Ac tristique libero volutpat at
@@ -56,6 +57,7 @@ Unordered
     * Facilisis in pretium nisl aliquet
 
     - Nulla volutpat aliquam velit
+
 - Very easy!
 
 Ordered
@@ -99,6 +101,12 @@ var foo = function (bar) {
 console.log(foo(5))
 ```
 
+Empty Block Test
+
+```
+
+```
+
 ## Tables
 
 | Option | Description                                                               |
@@ -138,12 +146,17 @@ With a reference later in the document defining the URL location:
 
 ## Math
 
-inline test: $\sqrt{x} = 100$
+inline test: $\sqrt{x} = 100$ and $e^{\sqrt{x}}$ something like. Also check $\frac{e^x + 3x}{2}$
 
 block test
 
 $$
 y=f(x) + x^2+\sin(x)
+$$
+
+Empty block test
+
+$$
 $$
 
 ## Plugins
@@ -171,3 +184,7 @@ Duplicated footnote reference[^second].
     and multiple paragraphs.
 
 [^second]: Footnote text.
+
+```
+
+```

--- a/src/backend/extensions/codeBlockExt.ts
+++ b/src/backend/extensions/codeBlockExt.ts
@@ -3,7 +3,7 @@ import { COPY_CODEBLOCK_CLASSNAME } from '@src/consts'
 import type { ParserContext } from '../parser'
 
 const codeBlockRegExp =
-  /(<pre>\s*<code[^>]*)(>(?:.(?!<\/code))*(?:.(?=<\/code))?<\/code>)\s*(<\/pre>)/gs
+  /(<pre>\s*<code[^>]*)(><\/code>|>(?:.(?!<\/code))*.<\/code>)\s*(<\/pre>)/gs
 
 export function createCodeBlockExt(context: ParserContext): ShowdownExtension {
   return {

--- a/src/backend/extensions/katexExt.ts
+++ b/src/backend/extensions/katexExt.ts
@@ -1,7 +1,7 @@
 import katex from 'katex'
 import type { ShowdownExtension } from 'showdown'
 
-const mathInlineRegExp = /¨D((?:[^\n](?!¨D))*(?:[^\n](?=¨D)))¨D/g
+const mathInlineRegExp = /¨D((?:[^\n](?!¨D))*[^\n])¨D/g
 const mathBlockRegExp = /¨D¨D\n([^¨D]*)¨D¨D(\n|$)/gs
 
 function createMathExt(regExp: RegExp, isBlock: boolean): ShowdownExtension {


### PR DESCRIPTION
# 변경 사항

- 아래와 같이 내용물이 비어있는 경우를 처리

```
<pre><code></code></pre>

$$
$$
```

- 정규표현식으로 `XX|X(.(?!X))*.X`는 X로 감싸진 내용물을 인식함. 단 내용물에 X가 중첩되는 경우는 정상동작이 보장되지 못함. (사실 그런 것은 정규 언어가 아니므로, 정규 표현식으로 표현이 불가능함)
- 불필요한 캡쳐 그룹 제거